### PR TITLE
Add support for `enum`.

### DIFF
--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -141,4 +141,8 @@ export class ObjectDocument extends Document {
   get(propertyPath) {
     return this._valueProxyFor(propertyPath).value;
   }
+
+  validValuesFor(propertyPath) {
+    return this._valueProxyFor(propertyPath)._property.validValues;
+  }
 }

--- a/addon/models/property.js
+++ b/addon/models/property.js
@@ -31,14 +31,14 @@ export default class Property {
   }
 
   isValid(object) {
-    let { properties } = this;
+    let { required, properties, validValues } = this;
 
-    for (let i = 0, l = this.required.length; i < l; i++) {
-      let required = this.required[i];
-      let value = object && object[required];
+    for (let i = 0, l = required.length; i < l; i++) {
+      let requiredPropertyName = required[i];
+      let value = object && object[requiredPropertyName];
 
       // handles nested properties
-      if (properties[required] && !properties[required].isValid(value)) {
+      if (properties[requiredPropertyName] && !properties[requiredPropertyName].isValid(value)) {
         return false;
       }
 
@@ -46,6 +46,11 @@ export default class Property {
       if (!value) {
         return false;
       }
+    }
+
+    // handles validValues / enum
+    if (validValues && validValues.indexOf(object) === -1) {
+      return false;
     }
 
     return true;

--- a/addon/models/property.js
+++ b/addon/models/property.js
@@ -22,6 +22,10 @@ export default class Property {
     return null;
   }
 
+  get validValues() {
+    return this._property.enum;
+  }
+
   buildDefaultValue() {
     return buildDefaultValueForType(this._property.type);
   }

--- a/tests/fixtures/default-nested-property-schema.js
+++ b/tests/fixtures/default-nested-property-schema.js
@@ -18,6 +18,18 @@ export default {
         'city': {
           'id': 'http://jsonschema.net/address/city',
           'type': 'string'
+        },
+        'state': {
+          id: 'http://jsonschema.net/address/state',
+          type: 'string',
+          enum: [
+            'RI',
+            'NY',
+            'IN',
+            'CA',
+            'UT',
+            'CO'
+          ]
         }
       },
       'required': [

--- a/tests/unit/models/document-test.js
+++ b/tests/unit/models/document-test.js
@@ -161,6 +161,13 @@ test('can access all items after creation', function(assert) {
   assert.deepEqual(result, [item1, item2]);
 });
 
+test('can get a list of validValues for a property', function(assert) {
+  let expectedValues = schemaFixture.properties.address.properties.state.enum;
+
+  assert.deepEqual(this.document.properties.address.properties.state.validValues, expectedValues);
+  assert.deepEqual(this.document.validValuesFor('address.state'), expectedValues);
+});
+
 skip('throw an error if calling `toJSON` when required fields are not specified');
 skip('handle array properties (where you have many of a given item)');
 skip('add validations when setting property types');

--- a/tests/unit/models/property-isValid-test.js
+++ b/tests/unit/models/property-isValid-test.js
@@ -30,8 +30,18 @@ const personWithNestedRequirements = {
       type: 'object',
       properties: {
         city: { type: 'string' },
-        state: { type: 'string' },
-        zip: { type: 'string' }
+        zip: { type: 'string' },
+        state: {
+          type: 'string',
+          enum: [
+            'RI',
+            'NY',
+            'IN',
+            'CA',
+            'UT',
+            'CO'
+          ]
+        }
       },
       required: [
         'city',
@@ -119,4 +129,20 @@ test('it is valid if required nested sub-properties exist are satisfied', functi
   };
 
   assert.ok(property.isValid(person), 'is valid when nested properties are satisfied');
+});
+
+test('it is invalid if required nested sub-properties do not match enum', function(assert) {
+  let property = new Property(personWithNestedRequirements);
+
+  let person = {
+    last: 'Jackson',
+    first: 'Max',
+    address: {
+      city: 'Ocala',
+      state: 'FL',
+      zip: '34471'
+    }
+  };
+
+  assert.notOk(property.isValid(person), 'is invalid when value is not in enum');
 });

--- a/tests/unit/models/property-test.js
+++ b/tests/unit/models/property-test.js
@@ -87,3 +87,14 @@ test('calling .properties when none exist returns null', function(assert) {
 
   assert.notOk(property.properties, 'returns falsey value when nested properties do not exist');
 });
+
+test('exposes `enum` property as `validValues`', function(assert) {
+  let values = [ 'foo', 'bar', 1, 2, 3];
+
+  property = new Property({
+    'type': 'string',
+    'enum': values.slice()
+  });
+
+  assert.deepEqual(property.validValues, values, 'listed enum was available as `validValues`');
+});


### PR DESCRIPTION
Supports the following API's:

```javascript
let document = schema.buildDocument();

document.validValuesFor('address.state'); // => values provided in `enum`
document.properties.address.properties.state.validValues; // => values provided in `enum`
```

Validations also added to ensure that a given properties `enum` is used when determining if `isValid` returns true/false.