### PR TITLE
Remove label fields, add prompt and description property meta

### DIFF
--- a/addon/models/property.js
+++ b/addon/models/property.js
@@ -22,6 +22,14 @@ export default class Property {
     return this._property.default;
   }
 
+  get prompt() {
+    return this._property.prompt;
+  }
+
+  get description() {
+    return this._property.description;
+  }
+
   get placeholder() {
     return this._property.placeholder;
   }

--- a/app/templates/components/schema-field-radio.hbs
+++ b/app/templates/components/schema-field-radio.hbs
@@ -1,17 +1,12 @@
-<div class="form-group">
-  {{#if property.title}}
-    <label for="{{key}}">{{property.title}}</label>
-  {{/if}}
-  <div class="radio">
-    <div>
-      {{#radio-button value=false groupValue=value name=key changed="changed"}}
-        False
-      {{/radio-button}}
-    </div>
-    <div>
-      {{#radio-button value=true groupValue=value name=key changed="changed"}}
-        True
-      {{/radio-button}}
-    </div>
+<div class="radio">
+  <div class="radio-button-option">
+    {{#radio-button value=false groupValue=value name=key changed="changed"}}
+      False
+    {{/radio-button}}
+  </div>
+  <div class="radio-button-option">
+    {{#radio-button value=true groupValue=value name=key changed="changed"}}
+      True
+    {{/radio-button}}
   </div>
 </div>

--- a/app/templates/components/schema-field-select.hbs
+++ b/app/templates/components/schema-field-select.hbs
@@ -1,15 +1,9 @@
-<div class="form-group">
-  {{#if property.title}}
-    <label for="{{key}}">{{property.title}}</label>
+ <select name="{{key}}" {{action 'update' on="change"}} class="form-control">
+  {{#if property.prompt}}
+    <option disabled selected={{if (not value) true null}}>{{property.prompt}}</option>
   {{/if}}
 
-  <select name="{{key}}" {{action 'update' on="change"}} class="form-control">
-    {{#if prompt}}
-      <option disabled selected={{if (not value) true null}}>{{prompt}}</option>
-    {{/if}}
-
-    {{#each property.validValues as |option|}}
-      <option selected={{if (eq value option) true null}} value={{option}}>{{option}}</option>
-    {{/each}}
-  </select>
-</div>
+  {{#each property.validValues as |option|}}
+    <option selected={{if (eq value option) true null}} value={{option}}>{{option}}</option>
+  {{/each}}
+</select>

--- a/app/templates/components/schema-field-text.hbs
+++ b/app/templates/components/schema-field-text.hbs
@@ -1,14 +1,8 @@
-<div class="form-group">
-  {{#if property.title}}
-    <label for="{{key}}">{{property.title}}</label>
-  {{/if}}
-
-  {{one-way-input
-    value=value
-    update=(action "update")
-    autofocus=true
-    name=key
-    placeholder=property.placeholder
-    class="form-control"
-  }}
-</div>
+{{one-way-input
+  value=value
+  update=(action "update")
+  autofocus=true
+  name=key
+  placeholder=property.placeholder
+  class="form-control"
+}}

--- a/tests/integration/components/schema-field-radio-test.js
+++ b/tests/integration/components/schema-field-radio-test.js
@@ -76,13 +76,12 @@ moduleForComponent('schema-field-radio', {
 
 // Test group 1: Adding item to array-base document
 
-test('Array document: has a label and a radio elements', function(assert) {
+test('Array document: has a radio elements', function(assert) {
   let newItem = this.arrayDocument.addItem();
 
   this.setProperties({ key: this.key, property: this.arrayProperty, newItem });
   this.render(hbs('{{schema-field-radio key=key property=property document=newItem}}'));
 
-  assert.equal(this.$('label:first').text(), 'Is Developer', 'label is correct');
   assert.equal(this.$('input[type="radio"][name="developer"]').length, 2, 'has two radio buttons');
 });
 

--- a/tests/integration/components/schema-field-select-test.js
+++ b/tests/integration/components/schema-field-select-test.js
@@ -77,13 +77,12 @@ moduleForComponent('schema-field-select', {
 
 // Test group 1: Adding item to array-base document
 
-test('Array document: has a label and a select element', function(assert) {
+test('Array document: has a select element with options', function(assert) {
   let newItem = this.arrayDocument.addItem();
 
   this.setProperties({ key: this.key, property: this.arrayProperty, newItem });
   this.render(hbs('{{schema-field-select key=key property=property document=newItem}}'));
 
-  assert.equal(this.$('label:first').text(), 'State', 'label is correct');
   assert.equal(this.$('select[name="state"]').length, 1, 'has a select element');
   assert.equal(this.$('select option').length, 6, 'has all 6 options');
 });
@@ -130,12 +129,11 @@ test('Array document: updates document when changed', function(assert) {
 
 // Test group 2: Root property in object-base document
 
-test('Object document root property: has a label and a select element', function(assert) {
+test('Object document root property: has a select element with options', function(assert) {
   this.setProperties({ key: this.key, property: this.objectProperty,
                        document: this.objectDocument });
   this.render(hbs('{{schema-field-select key=key property=property document=document}}'));
 
-  assert.equal(this.$('label:first').text(), 'State', 'label is correct');
   assert.equal(this.$('select[name="state"]').length, 1, 'has a select element');
   assert.equal(this.$('select option').length, 6, 'has all 6 options');
 });
@@ -182,12 +180,11 @@ test('Object document root property: updates document when changed', function(as
 
 // Test group 3: Nested property in object-base document
 
-test('Object document nested property: has a label and a select element', function(assert) {
+test('Object document nested property: has a select element with options', function(assert) {
   this.setProperties({ key: this.nestedKey, property: this.nestedProperty,
                        document: this.objectDocument });
   this.render(hbs('{{schema-field-select key=key property=property document=document}}'));
 
-  assert.equal(this.$('label:first').text(), 'State', 'label is correct');
   assert.equal(this.$('select[name="address.state"]').length, 1, 'has a select element');
   assert.equal(this.$('select option').length, 6, 'has all 6 options');
 });

--- a/tests/integration/components/schema-field-text-test.js
+++ b/tests/integration/components/schema-field-text-test.js
@@ -14,6 +14,7 @@ let arraySchema = {
         'id': 'http://jsonschema.net/0/description',
         'title': 'Description',
         'default': 'Headquarters',
+        'placeholder': 'e.g. Headquarters',
         'type': 'string'
       }
     },
@@ -84,14 +85,17 @@ moduleForComponent('schema-field-text', {
 
 // Test group 1: Adding item to array-base document
 
-test('Array document: has a label and text field', function(assert) {
+test('Array document: has a text field with a placeholder', function(assert) {
   let newItem = this.arrayDocument.addItem();
 
   this.setProperties({ key: this.key, property: this.arrayProperty, newItem });
   this.render(hbs('{{schema-field-text key=key property=property document=newItem}}'));
 
-  assert.equal(this.$('label:first').text(), 'Description');
-  assert.ok(this.$('input[name="description"][type="text"]').length, 'has a text field');
+  assert.ok(this.$('input[name="description"][type="text"]').length,
+            'has a text field');
+  assert.equal(this.$('input[name="description"][type="text"]:first').attr('placeholder'),
+              'e.g. Headquarters',
+              'has a placeholder');
 });
 
 test('Array document: uses existing document value if present', function(assert) {
@@ -131,12 +135,11 @@ test('Array document: updates document when changed', function(assert) {
 
 // Test group 2: Root property in object-base document
 
-test('Object document: has a label and text field', function(assert) {
+test('Object document: has a text field', function(assert) {
   this.setProperties({ key: this.key, property: this.objectProperty,
                        document: this.objectDocument });
   this.render(hbs('{{schema-field-text key=key property=property document=document}}'));
 
-  assert.equal(this.$('label:first').text(), 'Description');
   assert.ok(this.$('input[name="description"][type="text"]').length, 'has a text field');
 });
 
@@ -177,12 +180,11 @@ test('Object document: updates document when changed', function(assert) {
 
 // Test group 3: Nested property in object-base document
 
-test('Object document nested property: has a label and text field', function(assert) {
+test('Object document nested property: has a text field', function(assert) {
   this.setProperties({ key: this.nestedKey, property: this.nestedProperty,
                        document: this.objectDocument });
   this.render(hbs('{{schema-field-text key=key property=property document=document}}'));
 
-  assert.equal(this.$('label:first').text(), 'City');
   assert.ok(this.$('input[name="address.city"][type="text"]').length, 'has a text field');
 });
 

--- a/tests/unit/models/property-test.js
+++ b/tests/unit/models/property-test.js
@@ -109,10 +109,14 @@ test('exposes `default`, `title`, and `placeholder` properties', function(assert
     'type': 'string',
     'default': 'Turd Ferguson',
     'title': 'Contestant Name',
-    'placeholder': 'e.g. Sean Connery'
+    'placeholder': 'e.g. Sean Connery',
+    'prompt': 'Select a contestant',
+    'description': 'Which contestant is your favorite?'
   });
 
   assert.equal(property.placeholder, 'e.g. Sean Connery', 'placeholder returns placeholder');
   assert.equal(property.default, 'Turd Ferguson', 'default returns default value');
   assert.equal(property.title, 'Contestant Name', 'title returns property title');
+  assert.equal(property.description, 'Which contestant is your favorite?', 'title returns property description');
+  assert.equal(property.prompt, 'Select a contestant', 'title returns property prompt');
 });


### PR DESCRIPTION
cc @rwjblue 

* Removes `<label>`s from components.  The client should determine all view options, we shouldn't' impose any additional elements.
* Adds `property.prompt` and `property.description`. `property.prompt` is used as the placeholder for select components.

We are racking up quite a few view-related attributes on `Property`.  I'm wondering if they should be nested into something like `meta` or `viewProperties` so they can be accessed from a single method call.