### PR TITLE
Add document.removeItem.

### DIFF
--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -116,6 +116,11 @@ export class ArrayDocument extends Document {
     return this._documents[index];
   }
 
+  removeItem(index) {
+    this._documents.removeAt(index);
+    this._values.removeAt(index);
+  }
+
   allItems() {
     return this._documents.slice();
   }

--- a/tests/unit/models/document-test.js
+++ b/tests/unit/models/document-test.js
@@ -161,6 +161,47 @@ test('can access all items after creation', function(assert) {
   assert.deepEqual(result, [item1, item2]);
 });
 
+test('can remove an item from an array based document', function(assert) {
+  let item;
+
+  this.schema = new Schema(arrayBaseObjectFixture);
+  this.document = this.schema.buildDocument();
+
+  let expected1 = {
+    'description': 'stuff here',
+    'streetAddress': 'unknown st',
+    'city': 'hope',
+    'state': 'ri',
+    'zip': '02831'
+  };
+
+  let expected2 = {
+    'description': 'other stuff here',
+    'streetAddress': 'totally known st',
+    'city': 'hope',
+    'state': 'ri',
+    'zip': '02831'
+  };
+
+  item = this.document.addItem();
+  for (let key in expected1) {
+    item.set(key, expected1[key]);
+  }
+
+  item = this.document.addItem();
+  for (let key in expected2) {
+    item.set(key, expected2[key]);
+  }
+
+  let result = this.document.toJSON();
+
+  assert.deepEqual(result, [expected1, expected2]);
+
+  this.document.removeItem(1);
+
+  assert.deepEqual(result, [expected1]);
+});
+
 test('can get a list of validValues for a property', function(assert) {
   let expectedValues = schemaFixture.properties.address.properties.state.enum;
 


### PR DESCRIPTION
Supports removing an item from the array document type.

Fixes #10.