### PR TITLE
Temporarily disable SRI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-beta
+
 
 before_install:
   - "mkdir travis-phantomjs"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.4",
     "ember-cli-release": "0.2.8",
-    "ember-cli-sri": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "2.0.0",
     "ember-disable-prototype-extensions": "^1.0.0",


### PR DESCRIPTION
Due to https://github.com/ember-cli/ember-cli/issues/5110.

We will reenable when the ember-cli-sri has been updated to fix.