### PR TITLE
New Toggle component

### DIFF
--- a/addon/components/each-property/component.js
+++ b/addon/components/each-property/component.js
@@ -6,7 +6,11 @@ export function getPropertyInputType(property) {
   }
 
   if (property.type === 'boolean') {
-    return 'radio';
+    if (Ember.get(property, 'displayProperties.useToggle')) {
+      return 'toggle';
+    } else {
+      return 'radio';
+    }
   }
 
   return 'text';

--- a/addon/components/schema-field-toggle/component.js
+++ b/addon/components/schema-field-toggle/component.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export const DEFAULT_SIZE = 'medium';
+export const DEFAULT_SIZE = 'small';
 export const DEFAULT_SHOW_LABELS = false;
 export const DEFAULT_TRUE_LABEL = 'True';
 export const DEFAULT_FALSE_LABEL = 'False';

--- a/addon/components/schema-field-toggle/component.js
+++ b/addon/components/schema-field-toggle/component.js
@@ -1,0 +1,55 @@
+import Ember from 'ember';
+
+export const DEFAULT_SIZE = 'medium';
+export const DEFAULT_SHOW_LABELS = false;
+export const DEFAULT_TRUE_LABEL = 'True';
+export const DEFAULT_FALSE_LABEL = 'False';
+
+export default Ember.Component.extend({
+  init() {
+    this._super(...arguments);
+
+    let key = this.get('key');
+    let document = this.get('document');
+    let defaultValue = this.get('property.default');
+    let initialValue =  '';
+    let documentValue = document.get(key);
+
+    if (typeof defaultValue !== 'undefined') {
+      initialValue = defaultValue;
+    }
+
+    if (typeof documentValue !== 'undefined') {
+      initialValue = documentValue;
+    }
+
+    this.set('value', initialValue);
+  },
+
+  toggleSize: Ember.computed('property.displayProperties.toggleSize', function() {
+    return this.get('property.displayProperties.toggleSize') || DEFAULT_SIZE;
+  }),
+
+  showLabels: Ember.computed('property.displayProperties.showLabels', function() {
+    return this.get('property.displayProperties.showLabels') || DEFAULT_SHOW_LABELS;
+  }),
+
+  trueLabel: Ember.computed('property.displayProperties.labels.trueLabel', function() {
+    return this.get('property.displayProperties.labels.trueLabel') || DEFAULT_TRUE_LABEL;
+  }),
+
+  falseLabel: Ember.computed('property.displayProperties.labels.falseLabel', function() {
+    return this.get('property.displayProperties.labels.falseLabel') || DEFAULT_FALSE_LABEL;
+  }),
+
+  name: Ember.computed.alias('key'),
+
+  actions: {
+    onToggle(value) {
+      let document = this.get('document');
+
+      document.set(this.get('key'), value);
+      this.set('value', value);
+    }
+  }
+});

--- a/app/components/schema-field-toggle/component.js
+++ b/app/components/schema-field-toggle/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-json-schema/components/schema-field-toggle/component';

--- a/app/templates/components/schema-field-toggle.hbs
+++ b/app/templates/components/schema-field-toggle.hbs
@@ -1,0 +1,11 @@
+<div class="toggle">
+  {{x-toggle
+    size=toggleSize
+    toggled=value
+    showLabels=showLabels
+    toggle="onToggle"
+    off=falseLabel
+    on=trueLabel
+    name=name
+  }}
+</div>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.4",
     "ember-cli-release": "0.2.8",
+    "ember-cli-toggle": "^0.6.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "2.0.0",
     "ember-disable-prototype-extensions": "^1.0.0",

--- a/tests/integration/components/each-property-test.js
+++ b/tests/integration/components/each-property-test.js
@@ -17,6 +17,14 @@ let flatSchema = {
         'title': 'Primary location'
       }
     },
+    'isActive': {
+      'type': 'boolean',
+      'default': false,
+      'displayProperties': {
+        'title': 'Is Active Location?',
+        'useToggle': true
+      }
+    },
     'description': {
       'id': 'http://jsonschema.net/description',
       'default': 'Headquarters',
@@ -64,6 +72,14 @@ let nestedSchema = {
       'default': false,
       'displayProperties': {
         'title': 'Primary location'
+      }
+    },
+    'isActive': {
+      'type': 'boolean',
+      'default': false,
+      'displayProperties': {
+        'title': 'Is Active Location?',
+        'useToggle': true
       }
     },
     'description': {
@@ -126,6 +142,7 @@ test('can render flat schema document properties', function(assert) {
   `);
 
   assert.equal(this.$('input[type="radio"][name="primaryLocation"]').length, 2, 'has two radios');
+  assert.equal(this.$('.x-toggle-btn').length, 1, 'has a toggle button');
   assert.equal(this.$('input[type="text"][name="description"]').length, 1, 'has a description text field');
   assert.equal(this.$('input[type="text"][name="description"]').val(), 'Headquarters', 'description has default value');
   assert.equal(this.$('input[type="text"][name="city"]').length, 1, 'has a city text field');
@@ -148,6 +165,7 @@ test('can render nested schema document properties', function(assert) {
   `);
 
   assert.equal(this.$('input[type="radio"][name="primaryLocation"]').length, 2, 'has two radios');
+  assert.equal(this.$('.x-toggle-btn').length, 1, 'has a toggle button');
   assert.equal(this.$('input[type="text"][name="description"]').length, 1, 'has a description text field');
   assert.equal(this.$('input[type="text"][name="description"]').val(), 'Headquarters', 'description has default value');
   assert.equal(this.$('input[type="text"][name="address.city"]').length, 1, 'has a city text field');

--- a/tests/integration/components/schema-field-toggle-test.js
+++ b/tests/integration/components/schema-field-toggle-test.js
@@ -1,0 +1,188 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Schema from 'ember-json-schema/models/schema';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+let isDeveloperProperty = {
+  'id': 'http://jsonschema.net/0/is-developer',
+  'type': 'boolean',
+  'default': false,
+  'displayProperties': {
+    'title': 'Is Developer',
+    'toggleSize': 'small',
+    'showLabels': true,
+    'useToggle': true,
+    'labels': {
+      'trueLabel': 'Confirm',
+      'falseLabel': 'Deny'
+    }
+  }
+};
+
+let arraySchema = {
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'id': 'http://jsonschema.net',
+  'type': 'array',
+  'items': {
+    'id': 'http://jsonschema.net/0',
+    'type': 'object',
+    'properties': {
+      'developer': isDeveloperProperty
+    },
+    'required': [
+      'developer'
+    ]
+  },
+  'required': [
+    '0'
+  ]
+};
+
+let objectSchema = {
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'id': 'http://jsonschema.net',
+  'type': 'object',
+  'properties': {
+    'developer': isDeveloperProperty,
+    'securityOfficer': {
+      'id': 'http://jsonschema.net/address',
+      'type': 'object',
+      'properties': {
+        'developer': isDeveloperProperty
+      },
+      'required': [
+        'developer'
+      ]
+    }
+  },
+  'required': [
+    'developer'
+  ]
+};
+
+moduleForComponent('schema-field-toggle', {
+  integration: true,
+
+  beforeEach() {
+    this.key = 'developer';
+
+    // Test group 1: Array-base schema
+    this.arraySchema = new Schema(arraySchema);
+    this.arrayProperties = this.arraySchema.itemProperties;
+    this.arrayDocument = this.arraySchema.buildDocument();
+    this.arrayProperty = this.arrayProperties[this.key];
+
+    // Test group 2: Object-base schema root property
+    this.objectSchema = new Schema(objectSchema);
+    this.objectDocument = this.objectSchema.buildDocument();
+    this.objectProperties = this.objectSchema.properties;
+    this.objectProperty = this.objectProperties[this.key];
+
+    // Test group 3: Object-base schema nested property
+    this.nestedKey = 'securityOfficer.developer';
+    this.nestedProperty = this.objectProperties.securityOfficer.properties.developer;
+  }
+});
+
+// Test group 1: Adding item to array-base document
+
+test('Array document: has a toggle element with labels', function(assert) {
+  let newItem = this.arrayDocument.addItem();
+
+  this.setProperties({ key: this.key, property: this.arrayProperty, newItem });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=newItem}}'));
+
+  assert.ok(this.$('.toggle-prefix:contains(Deny)').length, 'Has a false label');
+  assert.ok(this.$('.toggle-postfix:contains(Confirm)').length, 'Has a true label');
+
+  let toggle = this.$('.x-toggle-btn');
+  assert.ok(toggle.length, 'has a toggle button');
+  toggle.click();
+
+  assert.ok(this.$('.x-toggle-container').hasClass('x-toggle-container-checked'), 'Clicking toggle changes state to checked');
+});
+
+test('Array document: uses existing document value if present', function(assert) {
+  let newItem = this.arrayDocument.addItem();
+  newItem.set('developer', true);
+
+  this.setProperties({ key: this.key, property: this.arrayProperty, newItem });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=newItem}}'));
+
+  assert.ok(this.$('.x-toggle-container').hasClass('x-toggle-container-checked'), 'Toggle is currently selected');
+});
+
+test('Array document: uses default value if present', function(assert) {
+  let newItem = this.arrayDocument.addItem();
+  let defaultValue = false;
+
+  this.setProperties({ key: this.key, property: this.arrayProperty, newItem });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=newItem}}'));
+
+  assert.equal(this.$('.x-toggle-container').hasClass('x-toggle-container-checked'), defaultValue, 'Toggle is not selected');
+});
+
+test('Array document: updates document when changed', function(assert) {
+  let newItem = this.arrayDocument.addItem();
+  let expected = true;
+
+  this.setProperties({ key: this.key, property: this.arrayProperty, newItem });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=newItem}}'));
+
+  assert.equal(this.$('.x-toggle-container').hasClass('x-toggle-container-checked'), false, 'Toggle is not selected');
+
+  this.$('.x-toggle-btn').click();
+
+  assert.equal(newItem.get(this.key), expected);
+});
+
+test('Toggle with disabled labels shouldn\'t show labels', function(assert) {
+  let obj = Ember.$.extend(true, {}, isDeveloperProperty);
+  obj.displayProperties.showLabels = false;
+  let schemaJSON = { 'type': 'object', 'properties': { 'developer': obj } };
+  let schema = new Schema(schemaJSON);
+  let doc = schema.buildDocument();
+  let property = schema.properties.developer;
+  let key = 'developer';
+
+  this.setProperties({ schema, doc, property, key });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=doc}}'));
+
+  assert.equal(this.$('.toggle-prefix:contains(Deny)').length, 0, 'Has no false label');
+  assert.equal(this.$('.toggle-postfix:contains(Confirm)').length, 0, 'Has no true label');
+});
+
+test('Toggle with custom labels', function(assert) {
+  let obj = Ember.$.extend(true, {}, isDeveloperProperty);
+  obj.displayProperties.showLabels = true;
+  obj.displayProperties.labels.trueLabel = 'Enabled';
+  obj.displayProperties.labels.falseLabel = 'Disabled';
+  let schemaJSON = { 'type': 'object', 'properties': { 'developer': obj } };
+  let schema = new Schema(schemaJSON);
+  let doc = schema.buildDocument();
+  let property = schema.properties.developer;
+  let key = 'developer';
+
+  this.setProperties({ schema, doc, property, key });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=doc}}'));
+
+  assert.equal(this.$('.toggle-prefix:contains(Disabled)').length, 1, 'Has enabled label');
+  assert.equal(this.$('.toggle-postfix:contains(Enabled)').length, 1, 'Has disabled label');
+});
+
+test('Toggle default labels', function(assert) {
+  let obj = Ember.$.extend(true, {}, isDeveloperProperty);
+  obj.displayProperties.showLabels = true;
+  obj.displayProperties.labels = undefined;
+  let schemaJSON = { 'type': 'object', 'properties': { 'developer': obj } };
+  let schema = new Schema(schemaJSON);
+  let doc = schema.buildDocument();
+  let property = schema.properties.developer;
+  let key = 'developer';
+
+  this.setProperties({ schema, doc, property, key });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=doc}}'));
+
+  assert.equal(this.$('.toggle-prefix:contains(False)').length, 1, 'Has True label');
+  assert.equal(this.$('.toggle-postfix:contains(True)').length, 1, 'Has False label');
+});


### PR DESCRIPTION
Originally, I intended this component to replace radio inputs for booleans, however I don't think that is now a good idea.  The issue is that toggles are restricted to just 2 states: true, or false. Whereas radios have 3 potential states: undefined, true, or false.  It would be a mistake to fully remove radio components.

Using toggles over radios does seem to improve the UX of SPD.

#### Before:
<img width="1332" alt="screenshot 2015-11-17 11 36 57" src="https://cloud.githubusercontent.com/assets/884151/11222211/4729de14-8d37-11e5-8702-872db9c74ce6.png">

#### After:
<img width="1314" alt="screenshot 2015-11-17 14 24 00" src="https://cloud.githubusercontent.com/assets/884151/11222216/4e7b7e34-8d37-11e5-906b-29670b71bcfe.png">

For your review @rwjblue 