### PR TITLE
Add `ObjectDocument#load` implementation.

### DIFF
--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -84,6 +84,10 @@ export default class Document {
     return this._values;
   }
 
+  load() {
+    throw new Error('Document#load must be overridden in the type specific base class');
+  }
+
   toJSON() {
     Ember.deprecate(
       'Using Document#toJSON is deprecated, please use Document#dump instead.',
@@ -157,10 +161,23 @@ export class ArrayDocument extends Document {
 }
 
 export class ObjectDocument extends Document {
-  constructor() {
+  constructor(schema, baseType, data) {
     super(...arguments);
 
     this._valueProxies = Object.create(null);
+
+    if (data) {
+      this.load(data);
+    }
+  }
+
+  load(data) {
+    let properties = Object.keys(data);
+    for (let i = 0, l = properties.length; i < l; i++) {
+      let propertyName = properties[i];
+
+      this.set(propertyName, data[propertyName]);
+    }
   }
 
   _valueProxyFor(path) {

--- a/tests/unit/models/object-document-test.js
+++ b/tests/unit/models/object-document-test.js
@@ -73,3 +73,31 @@ test('exposes `isValid` to determine if the full document is valid', function(as
   assert.equal(this.document.isValid, true, 'document is valid');
 });
 
+test('exposes a `load` method', function(assert) {
+  let input = {
+    address: {
+      streetAddress: '123 Blah St.',
+      city: 'Hope'
+    }
+  };
+
+  this.document.load(input);
+
+  let result = this.document.dump();
+
+  assert.deepEqual(input, result);
+});
+
+test('can access properties after `load`', function(assert) {
+  let input = {
+    address: {
+      streetAddress: '123 Blah St.',
+      city: 'Hope'
+    }
+  };
+
+  this.document.load(input);
+
+  assert.equal(this.document.get('address.city'), 'Hope');
+  assert.equal(this.document.get('address.streetAddress'), '123 Blah St.');
+});

--- a/tests/unit/models/schema-test.js
+++ b/tests/unit/models/schema-test.js
@@ -50,3 +50,17 @@ test('itemProperties returns a list of properties', function(assert) {
   assert.deepEqual(['description', 'streetAddress', 'city', 'state', 'zip'],
                    propertyKeys, 'known keys are present');
 });
+
+test('can build a new document prepopulated with data', function(assert) {
+  let input = {
+    address: {
+      streetAddress: '123 Blah St.',
+      city: 'Hope'
+    }
+  };
+
+  let document = schema.buildDocument(input);
+  let result = document.dump();
+
+  assert.deepEqual(input, result);
+});


### PR DESCRIPTION
Allows loading data by either passing data to `schema.buildDocument(someDataHere)` or `documentInstance.load(someDataHere)`.

Addresses #18.