### PR TITLE
Allow {"$ref": "#/path/to/property/definition"} in schema

### DIFF
--- a/addon/models/property.js
+++ b/addon/models/property.js
@@ -3,12 +3,13 @@ import buildDefaultValueForType from '../utils/build-default-value-for-type';
 import checkValidity from '../utils/check-validity';
 
 export default class Property {
-  constructor(property) {
+  constructor(property, schemaStack) {
     if (!property) {
       throw new Error('You must provide a property definition to the Property constructor.');
     }
 
     this._property = property;
+    this._schemaStack = schemaStack;
   }
 
   get type() {
@@ -31,6 +32,20 @@ export default class Property {
     return null;
   }
 
+  resolveURI(uri) {
+    let hashIdx = uri.indexOf('#');
+
+    if (hashIdx === -1) {
+      return this._property.properties[uri];
+    }
+
+    if (hashIdx === 0) {
+      return this._schemaStack[0].resolveURI(uri.substr(1));
+    }
+
+    throw new Error('Only relative root references are implemented');
+  }
+
   get validValues() {
     return this._property.enum;
   }
@@ -45,5 +60,9 @@ export default class Property {
 
   get required() {
     return this._property.required || [];
+  }
+
+  get schemaStack() {
+    return this._schemaStack;
   }
 }

--- a/addon/models/schema.js
+++ b/addon/models/schema.js
@@ -39,5 +39,26 @@ export default class Schema {
   _setupSchema(schema) {
     this._properties = null;
     this._schema = schema;
+    this._schemaStack = [this];
+  }
+
+  get schemaStack() {
+    return this._schemaStack;
+  }
+
+  resolveURI(uri) {
+    let parts = uri.split('/');
+    if (parts[0] === '' || parts[0] === '#') {
+      parts.shift();
+    }
+
+    let property = this._schema;
+
+    do {
+      let part = parts.shift();
+      property = property[part];
+    } while (parts.length > 0);
+
+    return property;
   }
 }

--- a/addon/utils/get-properties.js
+++ b/addon/utils/get-properties.js
@@ -1,6 +1,11 @@
+import Schema from '../models/schema';
 import Property from '../models/property';
 
 export default function(object, rawProperties) {
+  if (!(object instanceof Schema) && !(object instanceof Property)) {
+    throw new Error('You must provide a schema or a property object to get the properties for.');
+  }
+
   if (!object._properties) {
     let properties = object._properties = {};
     let keys = Object.keys(rawProperties);
@@ -9,7 +14,11 @@ export default function(object, rawProperties) {
       let key = keys[i];
       let rawProperty = rawProperties[key];
 
-      properties[key] = new Property(rawProperty);
+      while (rawProperty.$ref) {
+        rawProperty = object.resolveURI(rawProperty.$ref);
+      }
+
+      properties[key] = new Property(rawProperty, object.schemaStack);
     }
   }
 

--- a/tests/fixtures/ref-schema.js
+++ b/tests/fixtures/ref-schema.js
@@ -1,0 +1,32 @@
+// inspired by https://github.com/acornejo/jjv/blob/master/test/fixtures/ref.json
+
+export default {
+  'type': 'object',
+  'definitions': {
+    'text': {
+      'type': 'string'
+    },
+    'nestedvalue': {
+      'type': 'object',
+      'properties': {
+        'key': {
+          '$ref': '#/definitions/text'
+        },
+        'value': {
+          '$ref': '#/definitions/nestedvalue'
+        },
+        'required': [
+          'key'
+        ]
+      }
+    }
+  },
+  'properties': {
+    'str': {
+      '$ref': '#/definitions/text'
+    },
+    'nested': {
+      '$ref': '#/definitions/nestedvalue'
+    }
+  }
+};

--- a/tests/integration/models/document-observability-test.js
+++ b/tests/integration/models/document-observability-test.js
@@ -2,6 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import Schema from 'ember-json-schema/models/schema';
 import schemaFixture from '../../fixtures/default-nested-property-schema';
 import arrayBaseObjectFixture from '../../fixtures/location-schema';
+import refSchemaFixture from '../../fixtures/ref-schema';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('document observability', {
@@ -65,4 +66,29 @@ test('can observe array based document properties', function(assert) {
   }
 
   assert.equal(this.$().text(), 'hopeprovidence', 'adds new item value');
+});
+
+test('can observe referenced document properties', function(assert) {
+  this.schema = new Schema(refSchemaFixture);
+
+  let expected1 = {
+    'str': 'test',
+    'nested': {
+      'value': {
+        'value': {
+          'key': 'depth3'
+        }
+      }
+    }
+  };
+  this.document = this.schema.buildDocument(expected1);
+  this.set('doc', this.document);
+
+  this.render(hbs`{{doc.values.nested.value.value.key}}`);
+
+  assert.equal(this.$().text(), 'depth3', 'renders the correct initial value');
+
+  this.document.set('nested.value.value.key', 'DEPTH3');
+
+  assert.equal(this.$().text(), 'DEPTH3', 'updates the value');
 });

--- a/tests/unit/models/schema-test.js
+++ b/tests/unit/models/schema-test.js
@@ -4,6 +4,7 @@ import Document from 'ember-json-schema/models/document';
 import { module, test } from 'qunit';
 import schemaFixture from '../../fixtures/default-nested-property-schema';
 import arraySchemaFixture from '../../fixtures/location-schema';
+import refSchemaFixture from '../../fixtures/ref-schema';
 
 let schema;
 module('models/schema', {
@@ -35,6 +36,31 @@ test('accessing properties returns an instance of `Property` model', function(as
 
   assert.equal(schema.properties.address.type, 'object');
   assert.equal(schema.properties.phoneNumber.type, 'array');
+});
+
+test('properties expose a stack linking back to the original schema', function(assert) {
+  assert.equal(schema.properties.address.schemaStack.indexOf(schema), 0);
+});
+
+test('accessing referenced properties returns an instance of `Property` model', function(assert) {
+  schema = new Schema(refSchemaFixture);
+
+  assert.ok(schema.properties.str instanceof Property, 'str is an instance of Property');
+  assert.equal(schema.properties.str.type, 'string');
+
+  assert.ok(schema.properties.nested instanceof Property, 'nested is an instance of Property');
+  assert.equal(schema.properties.nested.type, 'object');
+});
+
+test('accessing recursive properties return instances of `Property` model', function(assert) {
+  schema = new Schema(refSchemaFixture);
+
+  assert.ok(schema.properties.nested instanceof Property);
+  assert.ok(schema.properties.nested.properties.value instanceof Property);
+  assert.ok(schema.properties.nested.properties.value.properties.value instanceof Property);
+
+  assert.equal(schema.properties.nested.properties.value.properties.value.type, 'object');
+  assert.equal(schema.properties.nested.properties.value.properties.value.properties.key.type, 'string');
 });
 
 test('can build a new document using this schema', function(assert) {


### PR DESCRIPTION
Hi,

I don't know what your goals with this plugin are; but they kind of align with so far with mine. For me the intention is making a customer configurable form editor. My previous implementation is based on an own DSL, but using JSON-schema notation seems a better way to, hence my interest in your approach.

This PR adds basic functionality for referencing properties; this allows for reuse and for recursion. So far this approach works, but it is obvious there is a lot of room for enhancements.

The lookup code is slightly based on https://github.com/acornejo/jjv

Hope this aligns with your goals too. Any way we can get in contact to discuss that?

Kind regards,
 Sjoerd