### PR TITLE
Disabled fields

### DIFF
--- a/addon/components/schema-field-radio/component.js
+++ b/addon/components/schema-field-radio/component.js
@@ -18,6 +18,7 @@ export default Ember.Component.extend({
     }
 
     this.set('value', initialValue);
+    document.set(key, initialValue);
   },
 
   actions: {

--- a/addon/components/schema-field-text/component.js
+++ b/addon/components/schema-field-text/component.js
@@ -1,4 +1,12 @@
 import Ember from 'ember';
 import SchemaFieldInitializerMixin from 'ember-json-schema/mixins/components/schema-field-initializer';
 
-export default Ember.Component.extend(SchemaFieldInitializerMixin, {});
+export default Ember.Component.extend(SchemaFieldInitializerMixin, {
+  disabled: Ember.computed('property.displayProperties.disabled', function() {
+    if (this.get('property.displayProperties.disabled')) {
+      return 'disabled';
+    }
+
+    return false;
+  })
+});

--- a/addon/components/schema-field-text/component.js
+++ b/addon/components/schema-field-text/component.js
@@ -1,12 +1,4 @@
 import Ember from 'ember';
 import SchemaFieldInitializerMixin from 'ember-json-schema/mixins/components/schema-field-initializer';
 
-export default Ember.Component.extend(SchemaFieldInitializerMixin, {
-  disabled: Ember.computed('property.displayProperties.disabled', function() {
-    if (this.get('property.displayProperties.disabled')) {
-      return 'disabled';
-    }
-
-    return false;
-  })
-});
+export default Ember.Component.extend(SchemaFieldInitializerMixin);

--- a/addon/mixins/components/schema-field-initializer.js
+++ b/addon/mixins/components/schema-field-initializer.js
@@ -10,6 +10,7 @@ export default Ember.Mixin.create({
     let initialValue = document.get(key) || defaultValue || '';
 
     this.set('value', initialValue);
+    document.set(key, initialValue);
   },
 
   getCurrentValue() {

--- a/addon/mixins/components/schema-field-initializer.js
+++ b/addon/mixins/components/schema-field-initializer.js
@@ -16,6 +16,14 @@ export default Ember.Mixin.create({
     this.$('input').val();
   },
 
+  disabled: Ember.computed('property.displayProperties.disabled', function() {
+    if (this.get('property.displayProperties.disabled')) {
+      return 'disabled';
+    }
+
+    return false;
+  }),
+
   actions: {
     update(value) {
       if (typeof value === 'undefined') {

--- a/app/templates/components/schema-field-radio.hbs
+++ b/app/templates/components/schema-field-radio.hbs
@@ -1,12 +1,15 @@
 <div class="radio">
   <div class="radio-button-option">
-    {{#radio-button value=false groupValue=value name=key changed="changed"}}
+    {{#radio-button value=false groupValue=value name=key changed="changed" disabled=property.displayProperties.disabled}}
       False
     {{/radio-button}}
   </div>
   <div class="radio-button-option">
-    {{#radio-button value=true groupValue=value name=key changed="changed"}}
+    {{#radio-button value=true groupValue=value name=key changed="changed" disabled=property.displayProperties.disabled}}
       True
     {{/radio-button}}
   </div>
 </div>
+
+Disabled: 
+{{property.displayProperties.disabled}}

--- a/app/templates/components/schema-field-radio.hbs
+++ b/app/templates/components/schema-field-radio.hbs
@@ -10,6 +10,3 @@
     {{/radio-button}}
   </div>
 </div>
-
-Disabled: 
-{{property.displayProperties.disabled}}

--- a/app/templates/components/schema-field-select.hbs
+++ b/app/templates/components/schema-field-select.hbs
@@ -1,6 +1,6 @@
- <select name="{{key}}" {{action 'update' on="change"}} class="form-control">
-  {{#if property.prompt}}
-    <option disabled selected={{if (not value) true null}}>{{property.prompt}}</option>
+ <select name="{{key}}" {{action 'update' on="change"}} class="form-control" disabled={{property.displayProperties.disabled}}>
+  {{#if property.displayProperties.prompt}}
+    <option disabled selected={{if (not value) true null}}>{{property.displayProperties.prompt}}</option>
   {{/if}}
 
   {{#each property.validValues as |option|}}

--- a/app/templates/components/schema-field-text.hbs
+++ b/app/templates/components/schema-field-text.hbs
@@ -5,4 +5,7 @@
   name=key
   placeholder=property.displayProperties.placeholder
   class="form-control"
+  disabled=disabled
 }}
+
+Disabed: {{disabled}}

--- a/app/templates/components/schema-field-text.hbs
+++ b/app/templates/components/schema-field-text.hbs
@@ -7,5 +7,3 @@
   class="form-control"
   disabled=disabled
 }}
-
-Disabed: {{disabled}}

--- a/app/templates/components/schema-field-toggle.hbs
+++ b/app/templates/components/schema-field-toggle.hbs
@@ -7,5 +7,6 @@
     off=falseLabel
     on=trueLabel
     name=name
+    disabled=property.displayProperties.disabled
   }}
 </div>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-one-way-input": "0.1.1",
+    "ember-one-way-input": "0.3.0",
     "ember-radio-button": "1.0.7",
     "ember-resolver": "^2.0.3",
     "ember-suave": "^1.2.0",

--- a/tests/integration/components/schema-field-radio-test.js
+++ b/tests/integration/components/schema-field-radio-test.js
@@ -52,6 +52,20 @@ let objectSchema = {
   ]
 };
 
+let disabledPropertySchema = {
+  'type': 'object',
+  'properties': {
+    'developer': {
+      'default': true,
+      'type': 'boolean',
+      'displayProperties': {
+        'title': 'Is Developer',
+        'disabled': true
+      }
+    }
+  }
+};
+
 moduleForComponent('schema-field-radio', {
   integration: true,
 
@@ -123,4 +137,42 @@ test('Array document: updates document when changed', function(assert) {
   this.$('input[type="radio"][value="true"]').click();
 
   assert.equal(newItem.get(this.key), expected);
+});
+
+test('When `disabled` displayProperty is true, radios should be disabled', function(assert) {
+  let schema = new Schema(disabledPropertySchema);
+  let document = schema.buildDocument();
+  let property = schema.properties.developer;
+
+  this.setProperties({ key: 'developer', property, document });
+  this.render(hbs('{{schema-field-radio key=key property=property document=document}}'));
+
+  let trueInput = this.$('input[type="radio"][value="true"]');
+  let falseInput = this.$('input[type="radio"][value="false"]');
+
+  assert.ok(trueInput.is(':disabled'), 'true input is disabled');
+  assert.ok(falseInput.is(':disabled'), 'false input is disabled');
+  assert.ok(trueInput.is(':checked'), 'true input is checked by default');
+  assert.ok(!falseInput.is(':checked'), 'false input is not checked by default');
+  assert.equal(document.get('developer'), true, 'document value is correct');
+});
+
+test('When `disabled` displayProperty is false, radios should not be disabled', function(assert) {
+  let propertySchema = Ember.$.extend(true, {}, disabledPropertySchema);
+  propertySchema.properties.developer.displayProperties.disabled = false;
+  let schema = new Schema(propertySchema);
+  let document = schema.buildDocument();
+  let property = schema.properties.developer;
+
+  this.setProperties({ key: 'developer', property, document });
+  this.render(hbs('{{schema-field-radio key=key property=property document=document}}'));
+
+  let trueInput = this.$('input[type="radio"][value="true"]');
+  let falseInput = this.$('input[type="radio"][value="false"]');
+
+  assert.ok(!trueInput.is(':disabled'), 'true input is not disabled');
+  assert.ok(!falseInput.is(':disabled'), 'false input is not disabled');
+  assert.ok(trueInput.is(':checked'), 'true input is checked by default');
+  assert.ok(!falseInput.is(':checked'), 'false input is not checked by default');
+  assert.equal(document.get('developer'), true, 'document value is correct');
 });

--- a/tests/integration/components/schema-field-radio-test.js
+++ b/tests/integration/components/schema-field-radio-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import Schema from 'ember-json-schema/models/schema';
 import hbs from 'htmlbars-inline-precompile';

--- a/tests/integration/components/schema-field-select-test.js
+++ b/tests/integration/components/schema-field-select-test.js
@@ -53,6 +53,21 @@ let objectSchema = {
   ]
 };
 
+let disabledPropertySchema = {
+  'type': 'object',
+  'properties': {
+    'state': {
+      'default': 'IN',
+      'type': 'string',
+      'enum': ['RI', 'NY', 'IN', 'CA', 'UT', 'CO'],
+      'displayProperties': {
+        'title': 'State',
+        'disabled': true
+      }
+    }
+  }
+};
+
 moduleForComponent('schema-field-select', {
   integration: true,
 
@@ -229,4 +244,34 @@ test('Object document nested property: updates document when changed', function(
   select.trigger('change');
 
   assert.equal(this.objectDocument.get(this.nestedKey), expected);
+});
+
+test('When `disabled` displayProperty is true, select should be disabled', function(assert) {
+  let schema = new Schema(disabledPropertySchema);
+  let document = schema.buildDocument();
+  let property = schema.properties.state;
+
+  this.setProperties({ key: 'state', property, document });
+  this.render(hbs('{{schema-field-select key=key property=property document=document}}'));
+
+  let select = this.$('select');
+  assert.ok(select.is(':disabled'), 'select is disabled');
+  assert.equal(select.val(), 'IN', 'default value is used in select');
+  assert.equal(document.get('state'), 'IN', 'document value is correct');
+});
+
+test('When `disabled` displayProperty is false, select should not be disabled', function(assert) {
+  let schemaProperty = Ember.$.extend(true, {}, disabledPropertySchema);
+  schemaProperty.properties.state.displayProperties.disabled = false;
+  let schema = new Schema(schemaProperty);
+  let document = schema.buildDocument();
+  let property = schema.properties.state;
+
+  this.setProperties({ key: 'state', property, document });
+  this.render(hbs('{{schema-field-select key=key property=property document=document}}'));
+
+  let select = this.$('select');
+  assert.ok(!select.is(':disabled'), 'select is not disabled');
+  assert.equal(select.val(), 'IN', 'default value is used in select');
+  assert.equal(document.get('state'), 'IN', 'document value is correct');
 });

--- a/tests/integration/components/schema-field-select-test.js
+++ b/tests/integration/components/schema-field-select-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import Schema from 'ember-json-schema/models/schema';
 import hbs from 'htmlbars-inline-precompile';

--- a/tests/integration/components/schema-field-text-test.js
+++ b/tests/integration/components/schema-field-text-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import Schema from 'ember-json-schema/models/schema';
 import hbs from 'htmlbars-inline-precompile';
@@ -259,7 +260,7 @@ test('When `disabled` displayProperty is true, text field should be disabled', f
 });
 
 test('When `disabled` displayProperty is false, text field should not disabled', function(assert) {
-  let propertySchema = Ember.$.extend(true, {}, disabledPropertySchema)
+  let propertySchema = Ember.$.extend(true, {}, disabledPropertySchema);
   propertySchema.properties.description.displayProperties.disabled = false;
   let schema = new Schema(propertySchema);
   let document = schema.buildDocument();

--- a/tests/integration/components/schema-field-text-test.js
+++ b/tests/integration/components/schema-field-text-test.js
@@ -36,9 +36,11 @@ let objectSchema = {
   'properties': {
     'description': {
       'id': 'http://jsonschema.net/description',
-      'title': 'Description',
       'default': 'Headquarters',
-      'type': 'string'
+      'type': 'string',
+      'displayProperties': {
+        'title': 'Description'
+      }
     },
     'address': {
       'id': 'http://jsonschema.net/address',
@@ -61,6 +63,21 @@ let objectSchema = {
   'required': [
     'description'
   ]
+};
+
+let disabledPropertySchema = {
+  'type': 'object',
+  'properties': {
+    'description': {
+      'id': 'http://jsonschema.net/description',
+      'default': 'Headquarters',
+      'type': 'string',
+      'displayProperties': {
+        'title': 'Description',
+        'disabled': true
+      }
+    }
+  }
 };
 
 moduleForComponent('schema-field-text', {
@@ -225,5 +242,35 @@ test('Object document nested property: updates document when changed', function(
   input.trigger('input');
 
   assert.equal(this.objectDocument.get(this.nestedKey), expected, 'new document value is correct');
+});
+
+test('When `disabled` displayProperty is true, text field should be disabled', function(assert) {
+  let schema = new Schema(disabledPropertySchema);
+  let document = schema.buildDocument();
+  let property = schema.properties.description;
+
+  this.setProperties({ key: 'description', property, document });
+  this.render(hbs('{{schema-field-text key=key property=property document=document}}'));
+
+  let input = this.$('input[type="text"]');
+  assert.ok(input.is(':disabled'), 'input is disabled');
+  assert.equal(input.val(), 'Headquarters', 'default value is used in input');
+  assert.equal(document.get('description'), 'Headquarters', 'document value is correct');
+});
+
+test('When `disabled` displayProperty is false, text field should not disabled', function(assert) {
+  let propertySchema = Ember.$.extend(true, {}, disabledPropertySchema)
+  propertySchema.properties.description.displayProperties.disabled = false;
+  let schema = new Schema(propertySchema);
+  let document = schema.buildDocument();
+  let property = schema.properties.description;
+
+  this.setProperties({ key: 'description', property, document });
+  this.render(hbs('{{schema-field-text key=key property=property document=document}}'));
+
+  let input = this.$('input[type="text"]');
+  assert.ok(!input.is(':disabled'), 'input is not disabled');
+  assert.equal(input.val(), 'Headquarters', 'default value is used in input');
+  assert.equal(document.get('description'), 'Headquarters', 'document value is correct');
 });
 

--- a/tests/integration/components/schema-field-toggle-test.js
+++ b/tests/integration/components/schema-field-toggle-test.js
@@ -60,6 +60,27 @@ let objectSchema = {
   ]
 };
 
+let disabledPropertySchema = {
+  'type': 'object',
+  'properties': {
+    'developer': {
+      'default': true,
+      'type': 'boolean',
+      'displayProperties': {
+        'title': 'Is Developer',
+        'disabled': true,
+        'toggleSize': 'small',
+        'showLabels': true,
+        'useToggle': true,
+        'labels': {
+          'trueLabel': 'Yes',
+          'falseLabel': 'No'
+        }
+      }
+    }
+  }
+};
+
 moduleForComponent('schema-field-toggle', {
   integration: true,
 
@@ -185,4 +206,34 @@ test('Toggle default labels', function(assert) {
 
   assert.equal(this.$('.toggle-prefix:contains(False)').length, 1, 'Has True label');
   assert.equal(this.$('.toggle-postfix:contains(True)').length, 1, 'Has False label');
+});
+
+test('When `disabled` displayProperty is true, toggle should be disabled', function(assert) {
+  let schema = new Schema(disabledPropertySchema);
+  let document = schema.buildDocument();
+  let property = schema.properties.developer;
+
+  this.setProperties({ key: 'developer', property, document });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=document}}'));
+
+  let toggle = this.$('.x-toggle-container');
+  assert.ok(toggle.hasClass('x-toggle-container-disabled'), 'toggle is disabled');
+  assert.ok(toggle.hasClass('x-toggle-container-checked'), 'default value is used');
+  assert.equal(document.get('developer'), true, 'document value is correct');
+});
+
+test('When `disabled` displayProperty is false, toggle should not be disabled', function(assert) {
+  let schemaProperty = Ember.$.extend(true, {}, disabledPropertySchema);
+  schemaProperty.properties.developer.displayProperties.disabled = false;
+  let schema = new Schema(schemaProperty);
+  let document = schema.buildDocument();
+  let property = schema.properties.developer;
+
+  this.setProperties({ key: 'developer', property, document });
+  this.render(hbs('{{schema-field-toggle key=key property=property document=document}}'));
+
+  let toggle = this.$('.x-toggle-container');
+  assert.ok(!toggle.hasClass('x-toggle-container-disabled'), 'toggle is not disabled');
+  assert.ok(toggle.hasClass('x-toggle-container-checked'), 'default value is used');
+  assert.equal(document.get('developer'), true, 'document value is correct');
 });


### PR DESCRIPTION
This PR adds support for disabling schema fields by setting  a `displayProperties.disabled` to true.

This also ensures that when a `default` value is defined on a property, it is also set on the document.  This is done in the individual field types initializer, but should probably be handled in `schema.buildDocument()` instead.  I'll open a separate ticket for that.

cc @rwjblue 

