### PR TITLE
Array object dump should be able to exclude invalid items [fixes #11]

### DIFF
--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -56,7 +56,7 @@ export class ArrayDocument extends Document {
 
   _buildDocumentInstance() {
     // TODO: handle array of arrays (WAT?)
-    let schema = new Schema(this._schema._schema.items);
+    let schema = new Schema(this._schemaItems);
     let document = schema.buildDocument();
 
     return document;
@@ -69,6 +69,21 @@ export class ArrayDocument extends Document {
 
     items.forEach((item) => {
       this.addItem(item);
+    });
+  }
+
+  dump(params = {}) {
+    if (params.excludeInvalid) {
+      return this.validValues();
+    } else {
+      return this._values;
+    }
+  }
+
+  validValues() {
+    return this._values.filter((value, index) => {
+      let document = this._documents[index];
+      return document.isValid;
     });
   }
 
@@ -111,6 +126,10 @@ export class ArrayDocument extends Document {
 
   allItems() {
     return this._documents.slice();
+  }
+
+  get _schemaItems() {
+    return this._schema._schema.items;
   }
 
   get values() {

--- a/tests/unit/models/array-document-test.js
+++ b/tests/unit/models/array-document-test.js
@@ -23,7 +23,7 @@ module('models/document', {
       'description': `stuff here ${++this.count}`,
       'streetAddress': `${++this.count} unknown st`,
       'city': 'hope',
-      'state': 'ri',
+      'state': 'RI',
       'zip': `${++this.count}${++this.count}${++this.count}${++this.count}${++this.count}`
     };
   }
@@ -38,6 +38,17 @@ test('add array as base object type using per-property syntax', function(assert)
   let result = this.document.dump();
 
   assert.deepEqual(result, [expected]);
+});
+
+test('`dump` with `excludeInvalid` should only include valid items', function(assert) {
+  let valid = this.buildLocation();
+
+  this.document.addItem(valid);
+  this.document.addItem();
+
+  let result = this.document.dump({ excludeInvalid: true });
+
+  assert.deepEqual(result, [valid]);
 });
 
 test('can add multiple items to an array based document using per-property syntax', function(assert) {


### PR DESCRIPTION
This adds an optional params hash to array-base documents `dump()` method.  When true, `dump()` will omit any invalid items included in the document.