### PR TITLE
Fix schema metadata

### DIFF
--- a/addon/mixins/components/schema-field-initializer.js
+++ b/addon/mixins/components/schema-field-initializer.js
@@ -17,8 +17,8 @@ export default Ember.Mixin.create({
     this.$('input').val();
   },
 
-  disabled: Ember.computed('property.displayProperties.disabled', function() {
-    if (this.get('property.displayProperties.disabled')) {
+  disabled: Ember.computed('property.readonly', function() {
+    if (this.get('property.readonly')) {
       return 'disabled';
     }
 

--- a/addon/models/property.js
+++ b/addon/models/property.js
@@ -24,6 +24,18 @@ export default class Property {
     return this._property.default;
   }
 
+  get readonly() {
+    return this._property.readonly || false;
+  }
+
+  get title() {
+    return this._property.title;
+  }
+
+  get description() {
+    return this._property.description;
+  }
+
   get properties() {
     if (this._property.properties) {
       return getProperties(this, this._property.properties);

--- a/app/templates/components/schema-field-radio.hbs
+++ b/app/templates/components/schema-field-radio.hbs
@@ -1,11 +1,11 @@
 <div class="radio">
   <div class="radio-button-option">
-    {{#radio-button value=false groupValue=value name=key changed="changed" disabled=property.displayProperties.disabled}}
+    {{#radio-button value=false groupValue=value name=key changed="changed" disabled=property.readonly}}
       False
     {{/radio-button}}
   </div>
   <div class="radio-button-option">
-    {{#radio-button value=true groupValue=value name=key changed="changed" disabled=property.displayProperties.disabled}}
+    {{#radio-button value=true groupValue=value name=key changed="changed" disabled=property.readonly}}
       True
     {{/radio-button}}
   </div>

--- a/app/templates/components/schema-field-select.hbs
+++ b/app/templates/components/schema-field-select.hbs
@@ -1,4 +1,4 @@
- <select name="{{key}}" {{action 'update' on="change"}} class="form-control" disabled={{property.displayProperties.disabled}}>
+ <select name="{{key}}" {{action 'update' on="change"}} class="form-control" disabled={{property.readonly}}>
   {{#if property.displayProperties.prompt}}
     <option disabled selected={{if (not value) true null}}>{{property.displayProperties.prompt}}</option>
   {{/if}}

--- a/app/templates/components/schema-field-toggle.hbs
+++ b/app/templates/components/schema-field-toggle.hbs
@@ -7,6 +7,6 @@
     off=falseLabel
     on=trueLabel
     name=name
-    disabled=property.displayProperties.disabled
+    disabled=property.readonly
   }}
 </div>

--- a/tests/integration/components/schema-field-radio-test.js
+++ b/tests/integration/components/schema-field-radio-test.js
@@ -7,9 +7,7 @@ let isDeveloperProperty = {
   'id': 'http://jsonschema.net/0/is-developer',
   'type': 'boolean',
   'default': false,
-  'displayProperties': {
-    'title': 'Is Developer'
-  }
+  'title': 'Is Developer'
 };
 
 let arraySchema = {
@@ -59,10 +57,8 @@ let disabledPropertySchema = {
     'developer': {
       'default': true,
       'type': 'boolean',
-      'displayProperties': {
-        'title': 'Is Developer',
-        'disabled': true
-      }
+      'readonly': true,
+      'title': 'Is Developer'
     }
   }
 };
@@ -140,7 +136,7 @@ test('Array document: updates document when changed', function(assert) {
   assert.equal(newItem.get(this.key), expected);
 });
 
-test('When `disabled` displayProperty is true, radios should be disabled', function(assert) {
+test('When `readonly` is true, radios should be disabled', function(assert) {
   let schema = new Schema(disabledPropertySchema);
   let document = schema.buildDocument();
   let property = schema.properties.developer;
@@ -158,9 +154,9 @@ test('When `disabled` displayProperty is true, radios should be disabled', funct
   assert.equal(document.get('developer'), true, 'document value is correct');
 });
 
-test('When `disabled` displayProperty is false, radios should not be disabled', function(assert) {
+test('When `readonly` is false, radios should not be disabled', function(assert) {
   let propertySchema = Ember.$.extend(true, {}, disabledPropertySchema);
-  propertySchema.properties.developer.displayProperties.disabled = false;
+  propertySchema.properties.developer.readonly = false;
   let schema = new Schema(propertySchema);
   let document = schema.buildDocument();
   let property = schema.properties.developer;

--- a/tests/integration/components/schema-field-select-test.js
+++ b/tests/integration/components/schema-field-select-test.js
@@ -8,9 +8,7 @@ let stateProperty = {
   'type': 'string',
   'default': 'NY',
   'enum': ['RI', 'NY', 'IN', 'CA', 'UT', 'CO'],
-  'displayProperties': {
-    'title': 'State'
-  }
+  'title': 'State'
 };
 
 let arraySchema = {
@@ -61,10 +59,8 @@ let disabledPropertySchema = {
       'default': 'IN',
       'type': 'string',
       'enum': ['RI', 'NY', 'IN', 'CA', 'UT', 'CO'],
-      'displayProperties': {
-        'title': 'State',
-        'disabled': true
-      }
+      'title': 'State',
+      'readonly': true
     }
   }
 };
@@ -247,7 +243,7 @@ test('Object document nested property: updates document when changed', function(
   assert.equal(this.objectDocument.get(this.nestedKey), expected);
 });
 
-test('When `disabled` displayProperty is true, select should be disabled', function(assert) {
+test('When `readonly` is true, select should be disabled', function(assert) {
   let schema = new Schema(disabledPropertySchema);
   let document = schema.buildDocument();
   let property = schema.properties.state;
@@ -261,9 +257,9 @@ test('When `disabled` displayProperty is true, select should be disabled', funct
   assert.equal(document.get('state'), 'IN', 'document value is correct');
 });
 
-test('When `disabled` displayProperty is false, select should not be disabled', function(assert) {
+test('When `readonly` is false, select should not be disabled', function(assert) {
   let schemaProperty = Ember.$.extend(true, {}, disabledPropertySchema);
-  schemaProperty.properties.state.displayProperties.disabled = false;
+  schemaProperty.properties.state.readonly = false;
   let schema = new Schema(schemaProperty);
   let document = schema.buildDocument();
   let property = schema.properties.state;

--- a/tests/integration/components/schema-field-text-test.js
+++ b/tests/integration/components/schema-field-text-test.js
@@ -15,8 +15,8 @@ let arraySchema = {
         'id': 'http://jsonschema.net/0/description',
         'default': 'Headquarters',
         'type': 'string',
+        'title': 'Description',
         'displayProperties': {
-          'title': 'Description',
           'placeholder': 'e.g. Headquarters'
         }
       }
@@ -39,9 +39,7 @@ let objectSchema = {
       'id': 'http://jsonschema.net/description',
       'default': 'Headquarters',
       'type': 'string',
-      'displayProperties': {
-        'title': 'Description'
-      }
+      'title': 'Description'
     },
     'address': {
       'id': 'http://jsonschema.net/address',
@@ -51,9 +49,7 @@ let objectSchema = {
           'id': 'http://jsonschema.net/address/city',
           'type': 'string',
           'default': 'Brooklyn',
-          'displayProperties': {
-            'title': 'City'
-          }
+          'title': 'City'
         }
       },
       'required': [
@@ -73,10 +69,8 @@ let disabledPropertySchema = {
       'id': 'http://jsonschema.net/description',
       'default': 'Headquarters',
       'type': 'string',
-      'displayProperties': {
-        'title': 'Description',
-        'disabled': true
-      }
+      'readonly': true,
+      'title': 'Description'
     }
   }
 };
@@ -245,7 +239,7 @@ test('Object document nested property: updates document when changed', function(
   assert.equal(this.objectDocument.get(this.nestedKey), expected, 'new document value is correct');
 });
 
-test('When `disabled` displayProperty is true, text field should be disabled', function(assert) {
+test('When `readonly` is true, text field should be disabled', function(assert) {
   let schema = new Schema(disabledPropertySchema);
   let document = schema.buildDocument();
   let property = schema.properties.description;
@@ -259,9 +253,9 @@ test('When `disabled` displayProperty is true, text field should be disabled', f
   assert.equal(document.get('description'), 'Headquarters', 'document value is correct');
 });
 
-test('When `disabled` displayProperty is false, text field should not disabled', function(assert) {
+test('When `readonly` is false, text field should not disabled', function(assert) {
   let propertySchema = Ember.$.extend(true, {}, disabledPropertySchema);
-  propertySchema.properties.description.displayProperties.disabled = false;
+  propertySchema.properties.description.readonly = false;
   let schema = new Schema(propertySchema);
   let document = schema.buildDocument();
   let property = schema.properties.description;

--- a/tests/integration/components/schema-field-toggle-test.js
+++ b/tests/integration/components/schema-field-toggle-test.js
@@ -66,9 +66,9 @@ let disabledPropertySchema = {
     'developer': {
       'default': true,
       'type': 'boolean',
+      'title': 'Is Developer',
+      'readonly': true,
       'displayProperties': {
-        'title': 'Is Developer',
-        'disabled': true,
         'toggleSize': 'small',
         'showLabels': true,
         'useToggle': true,
@@ -208,7 +208,7 @@ test('Toggle default labels', function(assert) {
   assert.equal(this.$('.toggle-postfix:contains(True)').length, 1, 'Has False label');
 });
 
-test('When `disabled` displayProperty is true, toggle should be disabled', function(assert) {
+test('When `readonly` is true, toggle should be disabled', function(assert) {
   let schema = new Schema(disabledPropertySchema);
   let document = schema.buildDocument();
   let property = schema.properties.developer;
@@ -222,9 +222,9 @@ test('When `disabled` displayProperty is true, toggle should be disabled', funct
   assert.equal(document.get('developer'), true, 'document value is correct');
 });
 
-test('When `disabled` displayProperty is false, toggle should not be disabled', function(assert) {
+test('When `readonly` is false, toggle should not be disabled', function(assert) {
   let schemaProperty = Ember.$.extend(true, {}, disabledPropertySchema);
-  schemaProperty.properties.developer.displayProperties.disabled = false;
+  schemaProperty.properties.developer.readonly = false;
   let schema = new Schema(schemaProperty);
   let document = schema.buildDocument();
   let property = schema.properties.developer;

--- a/tests/unit/models/property-test.js
+++ b/tests/unit/models/property-test.js
@@ -104,21 +104,54 @@ test('exposes `enum` property as `validValues`', function(assert) {
   assert.deepEqual(property.validValues, values, 'listed enum was available as `validValues`');
 });
 
-test('exposes displayProperties', function(assert) {
+test('exposes `displayProperties`', function(assert) {
   property = new Property({
-    type: 'string',
-    'default': 'Turd Ferguson',
-    displayProperties: {
-      title: 'Contestant Name',
-      placeholder: 'e.g. Sean Connery',
-      prompt: 'Select a contestant',
-      description: 'Which contestant is your favorite?'
+    'type': 'string',
+    'displayProperties': {
+      'placeholder': 'e.g. Sean Connery',
+      'prompt': 'Select a contestant'
     }
   });
 
-  assert.equal(property.displayProperties.placeholder, 'e.g. Sean Connery', 'placeholder returns placeholder');
-  assert.equal(property.default, 'Turd Ferguson', 'default returns default value');
-  assert.equal(property.displayProperties.title, 'Contestant Name', 'title returns property title');
-  assert.equal(property.displayProperties.description, 'Which contestant is your favorite?', 'title returns property description');
-  assert.equal(property.displayProperties.prompt, 'Select a contestant', 'title returns property prompt');
+  assert.equal(property.displayProperties.placeholder, 'e.g. Sean Connery', '`placeholder` returns placeholder');
+  assert.equal(property.displayProperties.prompt, 'Select a contestant', '`prompt` returns property prompt');
+});
+
+test('exposes `default`', function(assert) {
+  property = new Property({
+    'type': 'string',
+    'default': 'Turd Ferguson'
+  });
+
+  assert.equal(property.default, 'Turd Ferguson', '`default` returns default value');
+});
+
+test('exposes `title` and `description`', function(assert) {
+  property = new Property({
+    'type': 'string',
+    'title': 'Contestant Name',
+    'description': 'Which contestant is your favorite?'
+  });
+
+  assert.equal(property.title, 'Contestant Name', '`title` returns property title');
+  assert.equal(property.description, 'Which contestant is your favorite?', '`description` returns property description');
+});
+
+test('exposes `readonly` when true', function(assert) {
+  property = new Property({
+    'type': 'string',
+    'default': 'Turd Ferguson',
+    'readonly': true
+  });
+
+  assert.equal(property.readonly, true, '`readonly` returns true when set');
+});
+
+test('`readonly` returns false when undefined in schema', function(assert) {
+  property = new Property({
+    'type': 'string',
+    'default': 'Turd Ferguson'
+  });
+
+  assert.equal(property.readonly, false, '`readonly` returns false when undefined');
 });


### PR DESCRIPTION
Our assumption that `title`, `description`, and `disabled` are outside of the JSON schema 03 draft was incorrect.  This PR updates these three attributes to match the spec.

* `title` was moved from `displayProperties` to directly on property
* `description` was moved from `displayProperties` to directly on property
* `disabled` was renamed to `readonly` and moved from `displayProperties` to directly on property

